### PR TITLE
minor interface link changes (fixes #24 )

### DIFF
--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -16,7 +16,9 @@ export default function Footer() {
                 </div>
                 <div className="col-md-6 mx-2 flex-fill">
                     <h3 className="text-white fw-bold h4 text-uppercase">Want to learn more?</h3>
-                    <button className="w-50 btn rounded-0 btn-info text-white">GET IN TOUCH</button>
+                    <a href="https://oceaninfohub.org/contact-2/" target="_blank">
+                      <button className="w-50 btn rounded-0 btn-info text-white">GET IN TOUCH</button>
+                    </a>
                 </div>
             </div>
             <div className="container">

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -15,15 +15,17 @@ export default function Header() {
             <Navbar expand={false} variant="dark" className="navbar-oih pt-4" collapseOnSelect>
                 <Container id="NavContainer">
                     <Col md="auto">
-                        <Navbar.Brand className="text-white h6" href="/">Become a partner</Navbar.Brand>
+                        <Navbar.Brand className="text-white h6" href="https://oceaninfohub.org/contact-2/" target="_blank">Become a partner</Navbar.Brand>
                     </Col>
                     <Col md="auto">
                         <Navbar.Toggle aria-controls="responsive-navbar-nav"/>
                         <Navbar.Collapse id="responsive-navbar-nav">
                             <Nav className="mr-auto">
                                 <Nav.Link className="text-light menu-text" href="/">HOME</Nav.Link>
-                                <Nav.Link className="text-light menu-text" href="/">ABOUT</Nav.Link>
-                                <Nav.Link className="text-light menu-text" href="/">FAQ</Nav.Link>
+                                <Nav.Link className="text-light menu-text" href="https://oceaninfohub.org/about/project-overview/" target="_blank">ABOUT</Nav.Link>
+                                {/* <Nav.Link className="text-light menu-text" href="/">FAQ</Nav.Link> */}
+                                <Nav.Link className="text-light menu-text" href="http://graph.oceaninfohub.org/blazegraph/#query" target="_blank">ODIS GRAPH INTERFACE</Nav.Link>
+                                <Nav.Link className="text-light menu-text" href="http://catalogue.gatewaygeo.ca:8501/odis/dashboard/" target="_blank">ODIS DASHBOARD</Nav.Link>
                             </Nav>
                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" style={{fill: "#fff"}}
                                  width="30" height="30"

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import {Navbar, Nav, Form, FormControl, Button, NavDropdown, Container, Col} from 'react-bootstrap';
-import logo1 from '../resources/Logo Nav x 2.png'
+import logo1 from '../resources/Logo Nav x 2.png';
 
 export default function Header() {
-    const [showNav, setShowNav] = useState(true)
+    const [showNav, setShowNav] = useState(true);
 
     function closeSidebar() {
         const menubar = document.getElementById("responsive-navbar-nav");
-        menubar.classList.remove("show")
+        menubar.classList.remove("show");
     }
 
     return (
@@ -21,8 +21,8 @@ export default function Header() {
                         <Navbar.Toggle aria-controls="responsive-navbar-nav"/>
                         <Navbar.Collapse id="responsive-navbar-nav">
                             <Nav className="mr-auto">
-                                <Nav.Link className="text-light menu-text" href="/">HOME</Nav.Link>
-                                <Nav.Link className="text-light menu-text" href="https://oceaninfohub.org/about/project-overview/" target="_blank">ABOUT</Nav.Link>
+                                <Nav.Link className="text-light menu-text" href="https://oceaninfohub.org/" target="_blank">OIH HOME</Nav.Link>
+                                <Nav.Link className="text-light menu-text" href="https://oceaninfohub.org/about/project-overview/" target="_blank">ABOUT OIH</Nav.Link>
                                 {/* <Nav.Link className="text-light menu-text" href="/">FAQ</Nav.Link> */}
                                 <Nav.Link className="text-light menu-text" href="http://graph.oceaninfohub.org/blazegraph/#query" target="_blank">ODIS GRAPH INTERFACE</Nav.Link>
                                 <Nav.Link className="text-light menu-text" href="http://catalogue.gatewaygeo.ca:8501/odis/dashboard/" target="_blank">ODIS DASHBOARD</Nav.Link>


### PR DESCRIPTION
- in the top-right 'burger button' menu, this add links to the graph interface, and dashboard
  - points "About" to https://oceaninfohub.org/about/project-overview/
  - comments-out "FAQ" for now
- also points "Become a Partner" (in top-left) to https://oceaninfohub.org/contact-2/
(all links open in new browser tab, so user still has the search tool open)
- and points the "Get in Touch" button in footer to https://oceaninfohub.org/contact-2/

![Screenshot 2023-02-15 150520](https://user-images.githubusercontent.com/1611709/219127056-3b5d40db-305b-40cd-95cf-463700fc4267.png)

see staging at: https://oih.staging.gatewaygeo.ca/