### PR TITLE
add Backport action, check linefeed, etc.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,23 @@
+# Backport action, driven by a pull request's LABEL name
+#   if a pull request contains a label of "backport-branch-0-1", then
+#   this action will backport that pull request to "branch-0-1"
+# homepage: https://github.com/m-kuhn/backport
+
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport Bot
+        id: backport
+        if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )        
+        uses: m-kuhn/backport@v1.2.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -1,0 +1,18 @@
+# check for Windows CRLF in files
+# homepage: https://github.com/marketplace/actions/check-crlf
+
+name: Check CRLF
+
+on: [push, pull_request]
+
+jobs:
+  Check-CRLF:
+    name: verify that only LF linefeeds are used
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository contents
+        uses: actions/checkout@v1
+
+      - name: Use action to check for CRLF endings
+        uses: erclu/check-crlf@v1.2.0

--- a/.github/workflows/irc_notify.yml
+++ b/.github/workflows/irc_notify.yml
@@ -1,0 +1,47 @@
+# send build notifications to the #oih IRC channel
+# homepage: https://github.com/marketplace/actions/notify-irc
+
+name: "IRC Push Notification"
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  irc_notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: irc push
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'push'
+        with:
+          channel: "#oih"
+          server: "irc.libera.chat"
+          nickname: oih-github-notifier
+          notice: true
+          message: |
+            ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
+            ${{ join(github.event.commits.*.message) }}
+      - name: irc pull request
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'pull_request'
+        with:
+          channel: "#oih"
+          server: "irc.libera.chat"
+          nickname: oih-github-notifier
+          notice: true
+          message: |
+            ${{ github.actor }} opened PR ${{ github.event.pull_request.html_url }}
+      - name: irc tag created
+        uses: rectalogic/notify-irc@v1
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
+        with:
+          channel: "#oih"
+          server: "irc.libera.chat"
+          nickname: oih-github-notifier
+          notice: true          
+          message: |
+            ${{ github.actor }} tagged ${{ github.repository }} ${{ github.event.ref }}


### PR DESCRIPTION
- adds the following GitHub actions, that run for every Pull Request to this repository
  - Backport action
    - driven by a pull request's LABEL name
      - if a pull request contains a label of "backport-branch-0-1", then
      - this action will backport that pull request to "branch-0-1"
  - Check CRLF
    - this checks for nasty Windows linefeeds, that developers complain about often
  - notify IRC
    - this sends notices of pull requests to the `oih` IRC channel 
    - likely this will be only me using this ;)
    - PS. you can join that channel in your browser at https://web.libera.chat/#oih (you don't need a registered account, if you don't have one)