### PR TITLE
[indexer] handle both type:Project and type:ResearchProject

### DIFF
--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -146,6 +146,13 @@ def genericType_toAtts(orig, rid=None):
                 _id = hashlib.md5(name.encode('utf-8')).hexdigest()
             else:
                 _id = str(uuid.uuid4())
+                
+        #handle type:Project as type:ResearchProject (see issue#43)
+        if orig['@type'] == 'Project' or orig['@type'] == 'ResearchProject':
+          print('***changing type:Project to type:ResearchProject')
+          projectType = 'ResearchProject'
+        else:
+          projectType = orig['@type']                
 
         data = [
             Att(None, _id, 'id'),

--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -156,7 +156,7 @@ def genericType_toAtts(orig, rid=None):
 
         data = [
             Att(None, _id, 'id'),
-            Att(None, orig['@type'], 'type'),
+            Att(None, projectType, 'type'),
         ]
     except KeyError as msg:
         print("Error -- didn't get id or url and type")


### PR DESCRIPTION
- for now, set `type` to be `ResearchProject` for cases of `Project` or `ResearchProject`
- related to 
  - https://github.com/iodepo/oih-ui/issues/43
  - https://github.com/iodepo/odis-arch/issues/82