### PR TITLE
[indexer] handle trailing period in Address field

### DIFF
--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -150,13 +150,13 @@ def genericType_toAtts(orig, rid=None):
         #handle type:Project as type:ResearchProject (see issue#43)
         if orig['@type'] == 'Project' or orig['@type'] == 'ResearchProject':
           print('***changing type:Project to type:ResearchProject')
-          projectType = 'ResearchProject'
+          origType = 'ResearchProject'
         else:
-          projectType = orig['@type']                
+          origType = orig['@type']                
 
         data = [
             Att(None, _id, 'id'),
-            Att(None, projectType, 'type'),
+            Att(None, origType, 'type'),
         ]
     except KeyError as msg:
         print("Error -- didn't get id or url and type")

--- a/indexer/regions.py
+++ b/indexer/regions.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     print('regionForAddress tests...')
     for address in (
             'IOC Science and Communication Centre on Harmful Algae, University of Copenhagen - University of Copenhagen, Department of Biology - DK-1353 K\u00f8benhavn K - Denmark',
-            'Department of Marine and Fisheries Sciences, University of Ghana, P. O. BOX LG 99 Legon-Accra, Ghana.',
+            'P. O. BOX LG 99 Legon-Accra, Ghana.',
             ):
         print('    ',regionForAddress(address))
         

--- a/indexer/regions.py
+++ b/indexer/regions.py
@@ -51,6 +51,7 @@ def regionsForFeature(feature):
 #   Iran(Islamic Republic of),
 # * Remove stop words.
 # * Split on whitespace
+# * remove ending period e.g. we want "Ghana" from "Accra, Ghana."
 
 # Then, for properties mentioned above, we check to see if any of the 
 # countries are in the address, and map away from there.  Note, 
@@ -67,6 +68,7 @@ with open(os.path.join(os.path.dirname(__file__),'UNSD.Methodology.csv'), 'r') a
         s = s.lower()
         s = re.sub(r"\(.*\)","",s)
         s = re.sub(r"and|the|of","", s)
+        s = s.rstrip('.')
         return set(s.split(None))
     country_map_list = [(normalize(country),country) for country in text_regions.keys()]
 
@@ -104,6 +106,7 @@ if __name__ == '__main__':
     print('regionForAddress tests...')
     for address in (
             'IOC Science and Communication Centre on Harmful Algae, University of Copenhagen - University of Copenhagen, Department of Biology - DK-1353 K\u00f8benhavn K - Denmark',
+            'Department of Marine and Fisheries Sciences, University of Ghana, P. O. BOX LG 99 Legon-Accra, Ghana.',
             ):
         print('    ',regionForAddress(address))
         


### PR DESCRIPTION
- remove trailing period from `address`, so that the following address:
  ```
  P. O. BOX LG 99 Legon-Accra, Ghana.
  ```
  - returns values for `txt_region` of: 
    ```
     ['Africa', 'Sub-Saharan Africa']
    ```