### PR TITLE
handle duplicate License values

### DIFF
--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -332,7 +332,9 @@ def genericType_toAtts(orig, rid=None):
     if 'txt_nationality' in ret:
         ret['txt_nationality'] = list(set(ret['txt_nationality']))
     if 'txt_license' in ret:
-        ret['txt_license'] = list(set(ret['txt_license']))
+        #remove trailing slash in urls, for performing comparison
+        stripped_vals = [url.rstrip('/') for url in ret['txt_license']]
+        ret['txt_license'] = list(set(stripped_vals))
     return ret
 
 def _merge_prov(orig, prov):

--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -330,7 +330,9 @@ def genericType_toAtts(orig, rid=None):
     if 'txt_region' in ret:
         ret['txt_region'] = list(set(ret['txt_region']))
     if 'txt_nationality' in ret:
-        ret['txt_nationality'] = list(set(ret['txt_nationality']))        
+        ret['txt_nationality'] = list(set(ret['txt_nationality']))
+    if 'txt_license' in ret:
+        ret['txt_license'] = list(set(ret['txt_license']))
     return ret
 
 def _merge_prov(orig, prov):


### PR DESCRIPTION
Example:
```
License: CC-BY, https://creativecommons.org/licenses/by/4.0/, Attribution 4.0, CC-BY, https://creativecommons.org/licenses/by/4.0
```
Will change to:
```
License: CC-BY, https://creativecommons.org/licenses/by/4.0, Attribution 4.0
```