### PR TITLE
handle type:GeoCoordinates in JSON-LD

### DIFF
--- a/indexer/conversions.py
+++ b/indexer/conversions.py
@@ -132,6 +132,21 @@ def GeoShape(geo):
     raise UnhandledFormatException("Didn't handle %s in GeoShape" % json.dumps(geo))
 
 
+def GeoCoordinates(geo):
+    #print('here [GeoCoordinates]')
+
+    lat = geo.get("latitude",None)
+    long = geo.get("longitude",None)
+    if lat is not None and long is not None:
+        print ("Generating a Point from the GeoCoordinates...")
+        newPoint = "POINT (" + str(long) + " " + str(lat) + ")"
+        print(newPoint)
+        return _geo('point', newPoint)      
+      
+    raise UnhandledFormatException("Didn't handle %s in GeoCoordinates" % json.dumps(geo))
+
+
+
 def CourseInstance(data):
     atts = [_dispatch(field, data.get(field, None)) for field in ('startDate', 'endDate')]
     if 'location' in data:


### PR DESCRIPTION
- now leverages lat/long specified in partner's `type:GeoCoordinates` property
- related to https://github.com/iodepo/odis-arch/issues/276

