### PR TITLE
handle creditText in JSON-LD

### DIFF
--- a/frontend/src/components/results/types/Dataset.json
+++ b/frontend/src/components/results/types/Dataset.json
@@ -3,6 +3,7 @@
   { "key": "txt_sameAs", "type": ["list", "truncated", "link"] },
   { "key": "txt_license", "type": "list", "label": "License" },
   { "key": "txt_citation", "type": "list", "label": "Related Works" },
+  { "key": "txt_creditText", "type": "list", "label": "Recommended Citation" },
   "txt_version",
   { "key": "txt_keywords", "type": "keywords" },
   {


### PR DESCRIPTION
- displays the `creditText` property as "Recommended Citation"

related to https://github.com/iodepo/odis-arch/issues/276