### PR TITLE
[Solr] handle name as list

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -104,7 +104,7 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="_version_" type="string" indexed="true" stored="true"/>
     <field name="index_id" type="string" indexed="true" stored="true" required="true" />
     <field name="id" type="string" indexed="true" stored="true" required="true" />
-    <field name="name" type="string" indexed="true" stored="true" required="false" />
+    <field name="name" type="string" indexed="true" stored="true" required="false" multiValued="true" />
     <field name="type" type="string" indexed="true" stored="true" required="true" omitNorms="true" />
     <field name="description" type="textgen" indexed="true" stored="true" required="false" />
     <!-- source graph id -->


### PR DESCRIPTION
- allow multiple values for name
- otherwise an error is thrown in Solr
- sample:
```
    "contactPoint": {
      "@type": "ContactPoint",
      "contactType": "customer service",
      "name": [
        "Kile N.",
        "Johannes R.E."
      ],
```