### PR TITLE
handle ISO date with Z

### DIFF
--- a/indexer/conversions.py
+++ b/indexer/conversions.py
@@ -254,7 +254,7 @@ def _parseDate(field, d):
     try:
         dt = isoparse(d)
         return [
-            Att('dt', dt.isoformat(), field),
+            Att('dt', dt.isoformat(timespec='seconds').replace('+00:00', 'Z'), field),
             Att('n', dt.year, field.replace('Date', 'Year')),
         ]
     except ValueError:


### PR DESCRIPTION
- sample JSON-LD to handle:
  ```
    "temporalCoverage": "1992-02-08T12:00:00Z/2023-02-14T12:00:00Z",
  ```
related to https://github.com/iodepo/odis-arch/issues/355